### PR TITLE
Suppressing a cmake warning

### DIFF
--- a/python_module/cmake/add_python_export_library.cmake
+++ b/python_module/cmake/add_python_export_library.cmake
@@ -109,11 +109,8 @@ ${SETUP_PY_TEXT}
   # Link against boost::python
   target_link_libraries(${TARGET_NAME} ${Boost_LIBRARIES})
 
-  # On OSX and Linux, the python library must end in the extension .so. Build this
-  # filename here.
-  get_property(PYLIB_OUTPUT_FILE TARGET ${TARGET_NAME} PROPERTY LOCATION)
-  get_filename_component(PYLIB_OUTPUT_NAME ${PYLIB_OUTPUT_FILE} NAME_WE)
-  set(PYLIB_SO_NAME ${PYLIB_OUTPUT_NAME}.so)
+  # On OSX and Linux, the python library must end in the extension .so. 
+  set(PYLIB_SO_NAME lib${TARGET_NAME}.so)
 
   if(APPLE)
     SET(DIST_DIR site-packages)
@@ -130,7 +127,7 @@ ${SETUP_PY_TEXT}
   set(PYTHON_LIB_DIR ${CATKIN_DEVEL_PREFIX}/lib/python2.7/${DIST_DIR}/${PYTHON_PACKAGE_NAME})
   add_custom_command(TARGET ${TARGET_NAME}
     POST_BUILD
-    COMMAND mkdir -p ${PYTHON_LIB_DIR} && cp -v ${PYLIB_OUTPUT_FILE} ${PYTHON_LIB_DIR}/${PYLIB_SO_NAME}
+    COMMAND mkdir -p ${PYTHON_LIB_DIR} && cp -v $<TARGET_FILE:${TARGET_NAME}> ${PYTHON_LIB_DIR}/${PYLIB_SO_NAME}
     WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}
     COMMENT "Copying library files to python directory" )
 


### PR DESCRIPTION
```
delta:aslam $ cmake --help-policy CMP0026
CMP0026
-------

Disallow use of the LOCATION target property.

CMake 2.8.12 and lower allowed reading the LOCATION target
property (and configuration-specific variants) to
determine the eventual location of build targets.  This relies on the
assumption that all necessary information is available at
configure-time to determine the final location and filename of the
target.  However, this property is not fully determined until later at
generate-time.  At generate time, the $<TARGET_FILE> generator
expression can be used to determine the eventual LOCATION of a target
output.

Code which reads the LOCATION target property can be ported to use the
$<TARGET_FILE> generator expression together with the file(GENERATE)
subcommand to generate a file containing the target location.

The OLD behavior for this policy is to allow reading the LOCATION
properties from build-targets.  The NEW behavior for this policy is to
not to allow reading the LOCATION properties from build-targets.

This policy was introduced in CMake version 3.0.  CMake version
3.0.2 warns when the policy is not set and uses OLD behavior.  Use
the cmake_policy command to set it to OLD or NEW explicitly.
```