### PR TITLE
Added export capabilities for uint64 type

### DIFF
--- a/numpy_eigen/include/numpy_eigen/type_traits.hpp
+++ b/numpy_eigen/include/numpy_eigen/type_traits.hpp
@@ -39,6 +39,20 @@ template<> struct TypeToNumPy<boost::int64_t>
   }
 };
 
+template<> struct TypeToNumPy<boost::uint64_t>
+{
+  enum { NpyType = NPY_UINT64 };
+  static const char * npyString() { return "NPY_UINT64"; }
+  static const char * typeString() { return "ulong"; }
+  static bool canConvert(int type)
+  {
+    return type == NPY_UINT8 || type == NPY_USHORT ||
+           type == NPY_UINT16 || type == NPY_UINT32 || 
+           type == NPY_LONG || type == NPY_ULONGLONG || 
+           type == NPY_UINT64;
+  }
+};
+
 template<> struct TypeToNumPy<unsigned char>
 {
   enum { NpyType = NPY_UBYTE };

--- a/numpy_eigen/include/numpy_eigen/type_traits.hpp
+++ b/numpy_eigen/include/numpy_eigen/type_traits.hpp
@@ -43,12 +43,12 @@ template<> struct TypeToNumPy<boost::uint64_t>
 {
   enum { NpyType = NPY_UINT64 };
   static const char * npyString() { return "NPY_UINT64"; }
-  static const char * typeString() { return "ulong"; }
+  static const char * typeString() { return "uint64"; }
   static bool canConvert(int type)
   {
     return type == NPY_UINT8 || type == NPY_USHORT ||
            type == NPY_UINT16 || type == NPY_UINT32 || 
-           type == NPY_LONG || type == NPY_ULONGLONG || 
+           type == NPY_ULONG || type == NPY_ULONGLONG || 
            type == NPY_UINT64;
   }
 };


### PR DESCRIPTION
Export will not be enabled by default, but depending packages can just use the NumpyEigenConverter for that.