### PR TITLE
Add method to print sm::timing information in a sorted fashion

### DIFF
--- a/sm_timing/include/sm/timing/Timer.hpp
+++ b/sm_timing/include/sm/timing/Timer.hpp
@@ -80,6 +80,8 @@ namespace timing {
     size_t m_handle;
   };
   
+  enum SortType{SORT_BY_TOTAL, SORT_BY_MEAN, SORT_BY_STD, SORT_BY_MIN, SORT_BY_MAX, SORT_BY_NUM_SAMPLES};
+
   class Timing{
   public:
     friend class Timer;
@@ -101,9 +103,11 @@ namespace timing {
     static  double getHz(size_t handle);
     static  double getHz(std::string const & tag);
     static  void print(std::ostream & out);
+    static  void print(std::ostream & out, const SortType sort);
     static  void reset(size_t handle);
     static  void reset(std::string const & tag);
     static  std::string print();
+    static  std::string print(const SortType sort);
     static  std::string secondsToTimeString(double seconds);
     
   private:

--- a/sm_timing/include/sm/timing/Timer.hpp
+++ b/sm_timing/include/sm/timing/Timer.hpp
@@ -112,6 +112,9 @@ namespace timing {
     
   private:
     void addTime(size_t handle, double seconds);
+
+    template <typename TMap, typename Accessor>
+    static void print(const TMap & map, const Accessor & accessor, std::ostream & out);
     
     static Timing & instance();
     

--- a/sm_timing/src/Timer.cpp
+++ b/sm_timing/src/Timer.cpp
@@ -251,9 +251,6 @@ namespace timing {
   void Timing::print(std::ostream & out, const SortType sort) {
     map_t & tagMap = instance().m_tagMap;
 
-    out << "SM Timing\n";
-    out << "-----------\n";
-
     typedef std::multimap<double, std::string, std::greater<double> > SortMap_t;
     SortMap_t sorted;
     for(map_t::const_iterator t = tagMap.begin(); t != tagMap.end(); t++) {


### PR DESCRIPTION
Not the most performant method, but can be convienient from time to time