### PR TITLE
introduced humanReadableInputOutput for BoostPropertyTree

### DIFF
--- a/sm_property_tree/include/sm/BoostPropertyTree.hpp
+++ b/sm_property_tree/include/sm/BoostPropertyTree.hpp
@@ -58,9 +58,17 @@ namespace sm {
     iterator end() ;
     const_iterator end() const;    
 
+    static bool isHumanReadableInputOutput() {
+      return humanReadableInputOutput;
+    }
+
+    static void setHumanReadableInputOutput(bool humanReadableInputOutput) {
+      BoostPropertyTree::humanReadableInputOutput = humanReadableInputOutput;
+    }
   private:
     // It is important that this implementation have no members.
 
+    static bool humanReadableInputOutput;
   };
 
 

--- a/sm_property_tree/src/BoostPropertyTree.cpp
+++ b/sm_property_tree/src/BoostPropertyTree.cpp
@@ -6,6 +6,7 @@
 #include <sm/BoostPropertyTreeImplementation.hpp>
 
 namespace sm {
+  bool BoostPropertyTree::humanReadableInputOutput = false;
   
   BoostPropertyTree::BoostPropertyTree(const std::string & baseNamespace) :
     PropertyTree(boost::shared_ptr<PropertyTreeImplementation>(new BoostPropertyTreeImplementation), baseNamespace)

--- a/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
@@ -1,3 +1,4 @@
+#include <sm/BoostPropertyTree.hpp>
 #include <sm/BoostPropertyTreeImplementation.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/property_tree/xml_parser.hpp>
@@ -95,12 +96,18 @@ namespace sm {
 
   void BoostPropertyTreeImplementation::loadXml(const boost::filesystem::path & fileName)
   {
-    boost::property_tree::read_xml(fileName.string(), _ptree);
+    boost::property_tree::read_xml(fileName.string(), _ptree, BoostPropertyTree::isHumanReadableInputOutput() ? boost::property_tree::xml_parser::trim_whitespace : 0);
   }
 
   void BoostPropertyTreeImplementation::saveXml(const boost::filesystem::path & fileName) const
   {
-    boost::property_tree::write_xml(fileName.string(), _ptree);
+    if(BoostPropertyTree::isHumanReadableInputOutput()){
+      boost::property_tree::xml_writer_settings<ptree::key_type::value_type> settings('\t', 1);
+      boost::property_tree::write_xml(fileName.string(), _ptree, std::locale(), settings);
+    }
+    else {
+      boost::property_tree::write_xml(fileName.string(), _ptree);
+    }
   }
  
   void BoostPropertyTreeImplementation::loadIni(const boost::filesystem::path & fileName)

--- a/sm_property_tree/test/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/test/BoostPropertyTreeImplementation.cpp
@@ -122,3 +122,51 @@ TEST(PTreeTestSuite, testFindFile)
   // Let's test whether we can find a file
   EXPECT_NO_THROW(sm::findFile(".", "PWD"));
 }
+
+TEST(PTreeTestSuite, testHumanReadable)
+{
+  sm::BoostPropertyTree::setHumanReadableInputOutput(true);
+  sm::BoostPropertyTree wbpt;
+
+
+  wbpt.setDouble("a",0.1);
+  wbpt.setDouble("a/d",0.1);
+  wbpt.setDouble("a/b",0.2);
+  wbpt.setString("b","hello   "); // These spaces will get lost in a human readable XML context (see the expected value below)!
+  wbpt.setString("b/h","hello");
+  wbpt.setString("b/g","goodbye");
+  const std::string xmlFile = "testHumanReadable.xml";
+  wbpt.saveXml(xmlFile);
+
+  std::string expectedXml[] ={
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+      "<a>",
+      "\t0.1",
+      "\t<d>0.1</d>",
+      "\t<b>0.2</b>",
+      "</a>",
+      "<b>",
+      "\thello   ",
+      "\t<h>hello</h>",
+      "\t<g>goodbye</g>",
+      "</b>"
+  };
+
+  try
+  {
+    std::ifstream xmlFileStream(xmlFile);
+    int lineIndex = 0;
+    for(std::string line; std::getline(xmlFileStream, line); lineIndex++){
+      EXPECT_EQ(expectedXml[lineIndex], line);
+    }
+    xmlFileStream.close();
+
+    sm::BoostPropertyTree pt;
+    pt.loadXml(xmlFile);
+    EXPECT_EQ(pt.getString("b"), std::string("hello"));
+  }
+  catch(const std::exception & e)
+  {
+    FAIL() << "Unhandled exception: " << e.what();
+  }
+}


### PR DESCRIPTION
@uschwes , @pfmark , this is how I suggest a simple method to get human readable XMLs from the BoostPropertyTree: 
A user can globally activate human readable input output via 
```c++
sm::BoostPropertyTree::setHumanReadableInputOutput(true);
```