### PR TITLE
Pass boost library dependencies to downstream packages

### DIFF
--- a/sm_logging/CMakeLists.txt
+++ b/sm_logging/CMakeLists.txt
@@ -35,4 +35,7 @@ if(TARGET ${PROJECT_NAME}-test)
 endif()
 
 cs_install()
-cs_export(CFG_EXTRAS ${PROJECT_NAME}-extras.cmake)
+cs_export(
+  LIBRARIES ${Boost_LIBRARIES}
+  CFG_EXTRAS ${PROJECT_NAME}-extras.cmake
+)


### PR DESCRIPTION
Linker error otherwise