### PR TITLE
Fix/sm logging named streams

### DIFF
--- a/sm_logging/src/Formatter.cpp
+++ b/sm_logging/src/Formatter.cpp
@@ -55,6 +55,7 @@ namespace sm {
                     end = format_.end();
                     bool matched_once = false;
                     std::string last_suffix;
+                    tokens_.clear();
                     while (boost::regex_search(start, end, results, e))
                     {
 #if 0

--- a/sm_logging/src/LoggingGlobals.cpp
+++ b/sm_logging/src/LoggingGlobals.cpp
@@ -276,14 +276,20 @@ namespace sm {
         }
         bool isNamedStreamEnabled( const std::string & name )
         {
-            return g_logging_globals.isNamedStreamEnabled( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
+            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
+              return g_logging_globals.isNamedStreamEnabled( name );
+            return g_logging_globals.isNamedStreamEnabled( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name);
         }
         void enableNamedStream( const std::string & name )
         {
+            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
+              g_logging_globals.enableNamedStream( name );
             g_logging_globals.enableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
         }
         void disableNamedStream( const std::string & name )
         {
+            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
+              g_logging_globals.disableNamedStream( name );
             g_logging_globals.disableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
         }
 

--- a/sm_logging/src/LoggingGlobals.cpp
+++ b/sm_logging/src/LoggingGlobals.cpp
@@ -274,23 +274,26 @@ namespace sm {
         {
             return g_logging_globals.getLogger();
         }
+        
+        std::string addDefaultPrefixIfMissing(const std::string & name) {
+            if(name.substr(0, 3) == SMCONSOLE_DEFAULT_NAME "."){
+              return name;
+            }
+            else {
+              return std::string(SMCONSOLE_DEFAULT_NAME ".") + name;
+            }
+        }
         bool isNamedStreamEnabled( const std::string & name )
         {
-            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
-              return g_logging_globals.isNamedStreamEnabled( name );
-            return g_logging_globals.isNamedStreamEnabled( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name);
+            return g_logging_globals.isNamedStreamEnabled(addDefaultPrefixIfMissing(name));
         }
         void enableNamedStream( const std::string & name )
         {
-            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
-              g_logging_globals.enableNamedStream( name );
-            g_logging_globals.enableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
+            g_logging_globals.enableNamedStream(addDefaultPrefixIfMissing(name));
         }
         void disableNamedStream( const std::string & name )
         {
-            if (name.substr(0, 3) == std::string(SMCONSOLE_DEFAULT_NAME) + ".")
-              g_logging_globals.disableNamedStream( name );
-            g_logging_globals.disableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
+            g_logging_globals.disableNamedStream(addDefaultPrefixIfMissing(name));
         }
 
         

--- a/sm_logging/src/LoggingGlobals.cpp
+++ b/sm_logging/src/LoggingGlobals.cpp
@@ -276,15 +276,15 @@ namespace sm {
         }
         bool isNamedStreamEnabled( const std::string & name )
         {
-            return g_logging_globals.isNamedStreamEnabled( name );
+            return g_logging_globals.isNamedStreamEnabled( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
         }
         void enableNamedStream( const std::string & name )
         {
-            g_logging_globals.enableNamedStream( name );
+            g_logging_globals.enableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
         }
         void disableNamedStream( const std::string & name )
         {
-            g_logging_globals.disableNamedStream( name );
+            g_logging_globals.disableNamedStream( std::string(SMCONSOLE_DEFAULT_NAME) + "." + name );
         }
 
         

--- a/sm_logging/test/logTest.cpp
+++ b/sm_logging/test/logTest.cpp
@@ -74,6 +74,10 @@ TEST(LoggingTestSuite, testBasic) {
         SM_WARN_STREAM_NAMED("test", "Hey there: " << x);
         EXPECT_EQ("", logger->string());
 
+        // test deprecation solution
+        sm::logging::enableNamedStream("sm.test");
+        SM_WARN_STREAM_NAMED("test", "Hey there: " << x);
+        EXPECT_EQ("[ WARN]" + expected, logger->string());
 
         SM_INFO("This with printf: %d, %f, %s", 1, 1.0, "one");
 


### PR DESCRIPTION
Named streams are broken. Fix by prepending ```SMCONSOLE_DEFAULT_NAME``` to enable/disable stream methods.

Potential conflicts: People might have been aware of this bug and used ```sm::logging::enableNamedStream("sm.test")``` instead of ```sm::logging::enableNamedStream("test")``` to circumvent this problem.