### PR TITLE
Fix compatibility with boost >= 1.56 in portable_binary_iarchive

### DIFF
--- a/sm_boost/include/boost/portable_binary_iarchive.hpp
+++ b/sm_boost/include/boost/portable_binary_iarchive.hpp
@@ -85,9 +85,12 @@ class portable_binary_iarchive :
     >,
     public boost::archive::detail::common_iarchive<
         portable_binary_iarchive
-    >
-    ,
+    >,
+#if BOOST_VERSION >= 105600 // see changes in https://github.com/boostorg/serialization/commit/75f09afc895ab09c4eb55d36fcf6f91ef4a0107a
+    public boost::serialization::shared_ptr_helper<boost::shared_ptr>
+#else
     public boost::archive::detail::shared_ptr_helper
+#endif
     {
     typedef boost::archive::basic_binary_iprimitive<
         portable_binary_iarchive,

--- a/sm_boost/include/boost/portable_binary_iarchive.hpp
+++ b/sm_boost/include/boost/portable_binary_iarchive.hpp
@@ -27,7 +27,12 @@
 #include <boost/archive/archive_exception.hpp>
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/detail/common_iarchive.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105600 // see changes in https://github.com/boostorg/serialization/commit/75f09afc895ab09c4eb55d36fcf6f91ef4a0107a
+#include <boost/serialization/shared_ptr.hpp>
+#else
 #include <boost/archive/shared_ptr_helper.hpp>
+#endif
 #include <boost/archive/detail/register_archive.hpp>
 
 #include "portable_binary_archive.hpp"

--- a/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
@@ -102,8 +102,8 @@ namespace sm {
   void BoostPropertyTreeImplementation::saveXml(const boost::filesystem::path & fileName) const
   {
     if(BoostPropertyTree::isHumanReadableInputOutput()){
-      boost::property_tree::xml_writer_settings<ptree::key_type::value_type> settings('\t', 1);
-      boost::property_tree::write_xml(fileName.string(), _ptree, std::locale(), settings);
+      boost::property_tree::write_xml(fileName.string(), _ptree, std::locale(),
+                                      boost::property_tree::xml_writer_make_settings<ptree::key_type>('\t', 1));
     }
     else {
       boost::property_tree::write_xml(fileName.string(), _ptree);

--- a/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
@@ -4,6 +4,7 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/info_parser.hpp>
+#include <boost/version.hpp>
 
 namespace sm {
   
@@ -102,8 +103,13 @@ namespace sm {
   void BoostPropertyTreeImplementation::saveXml(const boost::filesystem::path & fileName) const
   {
     if(BoostPropertyTree::isHumanReadableInputOutput()){
+#if BOOST_VERSION >= 105600
       boost::property_tree::write_xml(fileName.string(), _ptree, std::locale(),
                                       boost::property_tree::xml_writer_make_settings<ptree::key_type>('\t', 1));
+#else
+      boost::property_tree::xml_writer_settings<ptree::key_type::value_type> settings('\t', 1);
+      boost::property_tree::write_xml(fileName.string(), _ptree, std::locale(), settings);
+#endif
     }
     else {
       boost::property_tree::write_xml(fileName.string(), _ptree);


### PR DESCRIPTION
(addressing #142)