### PR TITLE
Add dummy throw to supress compiler warnings for SM_THROW

### DIFF
--- a/sm_common/include/sm/assert_macros.hpp
+++ b/sm_common/include/sm/assert_macros.hpp
@@ -73,6 +73,7 @@ namespace sm {
     std::stringstream sm_assert_stringstream;							\
     sm_assert_stringstream << message;									\
     sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", __FUNCTION__,__FILE__,__LINE__, sm_assert_stringstream.str()); \
+    throw 0; /* to disable some compiler warnings */ \
   }
 
 
@@ -80,6 +81,7 @@ namespace sm {
     std::stringstream sm_assert_stringstream;							\
     sm_assert_stringstream << message;									\
     sm::detail::sm_throw_exception<exceptionType>("[" #exceptionType "] ", SourceFilePos, sm_assert_stringstream.str()); \
+    throw 0; /* to disable some compiler warnings */ \
   }
 
 #define SM_ASSERT_TRUE(exceptionType, condition, message)				\


### PR DESCRIPTION
The compiler does not realize that SM_THROW throws for sure and certain code locations cannot be reached, hence some warnings