### PR TITLE
Feature/property tree constcorrectness

### DIFF
--- a/sm_eigen/CMakeLists.txt
+++ b/sm_eigen/CMakeLists.txt
@@ -6,7 +6,7 @@ catkin_simple()
 
 find_package(Boost REQUIRED COMPONENTS system serialization)
 
-include_directories(${Eigen_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
 
 ##############
 ## Building ##

--- a/sm_eigen/include/sm/eigen/property_tree.hpp
+++ b/sm_eigen/include/sm/eigen/property_tree.hpp
@@ -7,7 +7,7 @@
 namespace sm {
     namespace eigen {
         
-        inline Eigen::Vector3d vector3FromPropertyTree(const sm::PropertyTree & config)
+        inline Eigen::Vector3d vector3FromPropertyTree(const sm::ConstPropertyTree & config)
         {
             Eigen::Vector3d rval;
             rval[0] = config.getDouble("x");
@@ -18,7 +18,7 @@ namespace sm {
         }
 
 
-        inline Eigen::Vector4d quaternionFromPropertyTree(const sm::PropertyTree & config)
+        inline Eigen::Vector4d quaternionFromPropertyTree(const sm::ConstPropertyTree & config)
         {
             Eigen::Vector4d rval;
             rval[0] = config.getDouble("x");

--- a/sm_kinematics/include/sm/kinematics/property_tree.hpp
+++ b/sm_kinematics/include/sm/kinematics/property_tree.hpp
@@ -7,11 +7,11 @@
 namespace sm {
     namespace kinematics {
         
-        inline sm::kinematics::Transformation transformationFromPropertyTree(const sm::PropertyTree & config)
+        inline sm::kinematics::Transformation transformationFromPropertyTree(const sm::ConstPropertyTree & config)
         {
-            Eigen::Vector4d q = sm::eigen::quaternionFromPropertyTree( sm::PropertyTree(config, "q_a_b") );
+            Eigen::Vector4d q = sm::eigen::quaternionFromPropertyTree( sm::ConstPropertyTree(config, "q_a_b") );
             q = q / q.norm();
-            Eigen::Vector3d t = sm::eigen::vector3FromPropertyTree( sm::PropertyTree(config, "t_a_b_a" ) );
+            Eigen::Vector3d t = sm::eigen::vector3FromPropertyTree( sm::ConstPropertyTree(config, "t_a_b_a" ) );
             return sm::kinematics::Transformation(q,t);
         }
 

--- a/sm_property_tree/include/sm/BoostPropertyTreeImplementation.hpp
+++ b/sm_property_tree/include/sm/BoostPropertyTreeImplementation.hpp
@@ -61,8 +61,7 @@ namespace sm {
     iterator end() ;
     const_iterator end() const;    
 
-    const std::vector<KeyPropertyTreePair> getChildren(const std::string & key) const;
-    std::vector<KeyPropertyTreePair> getChildren(const std::string & key);
+    std::vector<KeyPropertyTreePair> getChildren(const std::string & key) const;
   private:
 
     static int getXmlReadOptions();

--- a/sm_property_tree/include/sm/PropertyTree.hpp
+++ b/sm_property_tree/include/sm/PropertyTree.hpp
@@ -1,5 +1,5 @@
 /**
- * @file   PropertyTree.hpp
+ * @file   .hpp
  * @author Paul Furgale <paul.furgale@gmail.com>
  * @date   Tue Apr  3 09:39:01 2012
  *
@@ -19,6 +19,7 @@
 namespace sm {
   // Forward declaration.
   class PropertyTreeImplementation;
+  struct ConstKeyPropertyTreePair;
   struct KeyPropertyTreePair;
 
 
@@ -87,57 +88,88 @@ namespace sm {
    *   The classes BoostPropertyTreeImplementation and BoostPropertyTree are good examples of how to do this.
    *
    */
-  class PropertyTree
-  {
-  public:
+
+  class ConstPropertyTree {
+   public:
     SM_DEFINE_EXCEPTION(Exception, std::runtime_error);
     SM_DEFINE_EXCEPTION(InvalidKeyException, Exception);
     SM_DEFINE_EXCEPTION(InvalidValueException, Exception);
     SM_DEFINE_EXCEPTION(KeyNotFoundException, Exception);
 
-    PropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace = "");
-    PropertyTree(const PropertyTree & parent, const std::string & childNamespace);
+    ConstPropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace = "");
+    ConstPropertyTree(const ConstPropertyTree & parent, const std::string & childNamespace);
+    virtual ~ConstPropertyTree();
 
-    virtual ~PropertyTree();
+    const ConstPropertyTree getChild(const std::string & childNamespace) const {
+      return ConstPropertyTree(*this, childNamespace);
+    }
 
     double getDouble(const std::string & key) const;
     double getDouble(const std::string & key, double defaultValue) const;
-    double getDouble(const std::string & key, double defaultValue);
 
     int getInt(const std::string & key) const;
     int getInt(const std::string & key, int defaultValue) const;
-    // The non-const version will call "set" if the value is not already set.
-    int getInt(const std::string & key, int defaultValue);
 
     bool getBool(const std::string & key) const;
     bool getBool(const std::string & key, bool defaultValue) const;
-    // The non-const version will call setBool if the value is not already set.
-    bool getBool(const std::string & key, bool defaultValue);
 
     std::string getString(const std::string & key) const;
     std::string getString(const std::string & key, const std::string & defaultValue) const;
+
+
+    bool doesKeyExist(const std::string & key) const;
+
+    std::vector<ConstKeyPropertyTreePair> getChildren() const;
+   protected:
+     std::string _namespace;
+     std::string buildQualifiedKeyName(const std::string & key) const;
+     boost::shared_ptr<PropertyTreeImplementation> _imp;
+  };
+
+  class PropertyTree : public ConstPropertyTree
+  {
+   public:
+    PropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace = "");
+    PropertyTree(const PropertyTree & parent, const std::string & childNamespace);
+    virtual ~PropertyTree();
+
+    PropertyTree getChild(const std::string & childNamespace) const {
+      return PropertyTree(*this, childNamespace);
+    }
+
+    using ConstPropertyTree::getDouble;
+    // The non-const version will call "set" if the value is not already set.
+    double getDouble(const std::string & key, double defaultValue);
+
+    using ConstPropertyTree::getInt;
+    // The non-const version will call "set" if the value is not already set.
+    int getInt(const std::string & key, int defaultValue);
+
+    using ConstPropertyTree::getBool;
     // The non-const version will call setBool if the value is not already set.
-    std::string getString(const std::string & key, const std::string & defaultValue) ;
+    bool getBool(const std::string & key, bool defaultValue);
+
+    using ConstPropertyTree::getString;
+    // The non-const version will call setBool if the value is not already set.
+    std::string getString(const std::string & key, const std::string & defaultValue);
 
     void setDouble(const std::string & key, double value);
     void setInt(const std::string & key, int value);
     void setBool(const std::string & key, bool value) ;
     void setString(const std::string & key, const std::string & value);
 
-
-    bool doesKeyExist(const std::string & key) const;
-
-    const std::vector<KeyPropertyTreePair> getChildren() const;
-    std::vector<KeyPropertyTreePair> getChildren();
-  protected:
-    std::string _namespace;
-    std::string buildQualifiedKeyName(const std::string & key) const;
-    boost::shared_ptr<PropertyTreeImplementation> _imp;
+    using ConstPropertyTree::getChildren;
+    std::vector<KeyPropertyTreePair> getChildren() const;
   };
 
   struct KeyPropertyTreePair {
     std::string key;
     PropertyTree pt;
+  };
+
+  struct ConstKeyPropertyTreePair {
+    std::string key;
+    ConstPropertyTree pt;
   };
 
 } // namespace sm

--- a/sm_property_tree/include/sm/PropertyTreeImplementation.hpp
+++ b/sm_property_tree/include/sm/PropertyTreeImplementation.hpp
@@ -14,6 +14,7 @@ namespace sm {
 
     virtual double getDouble(const std::string & key) const = 0;
     virtual double getDouble(const std::string & key, double defaultValue) const = 0;
+    // The non-const version will call "set" if the value is not already set.
     virtual double getDouble(const std::string & key, double defaultValue) = 0;
 
     virtual int getInt(const std::string & key) const = 0;
@@ -38,8 +39,7 @@ namespace sm {
 
     virtual bool doesKeyExist(const std::string & key) const = 0;
 
-    virtual const std::vector<KeyPropertyTreePair> getChildren(const std::string & key) const = 0;
-    virtual std::vector<KeyPropertyTreePair> getChildren(const std::string & key) = 0;
+    virtual std::vector<KeyPropertyTreePair> getChildren(const std::string & key) const = 0;
   };
 
 } // namespace sm

--- a/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/src/BoostPropertyTreeImplementation.cpp
@@ -245,12 +245,7 @@ namespace sm {
     return _ptree.end();
   }
 
-
-  const std::vector<KeyPropertyTreePair> sm::BoostPropertyTreeImplementation::getChildren(const std::string & key) const {
-    return const_cast<BoostPropertyTreeImplementation*>(this)->getChildren(key);
-  }
-
-  std::vector<KeyPropertyTreePair> sm::BoostPropertyTreeImplementation::getChildren(const std::string & key) {
+  std::vector<KeyPropertyTreePair> sm::BoostPropertyTreeImplementation::getChildren(const std::string & key) const {
     std::vector<KeyPropertyTreePair> ret;
     auto * pt = &_ptree;
     std::string k;

--- a/sm_property_tree/src/PropertyTree.cpp
+++ b/sm_property_tree/src/PropertyTree.cpp
@@ -4,27 +4,43 @@
 
 namespace sm {
   
-  PropertyTree::PropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace) : 
-    _namespace(ensureTrailingBackslash(baseNamespace)), _imp(imp)
+  ConstPropertyTree::ConstPropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace) :
+          _namespace(ensureTrailingBackslash(baseNamespace)), _imp(imp)
   {
     if(_namespace.size() > 0 && _namespace[0] != '/')
       _namespace = "/" + _namespace;
   }
-  
-  PropertyTree::PropertyTree(const PropertyTree & parent, const std::string & childNamespace) :
-     _imp(parent._imp)
+
+  ConstPropertyTree::ConstPropertyTree(const ConstPropertyTree & parent, const std::string & childNamespace) :
+         _imp(parent._imp)
   {
-      if(childNamespace.size() > 0 && childNamespace[0] == '/')
-      {
-          _namespace = ensureTrailingBackslash(childNamespace);
-      }
-      else 
-      {
-          _namespace = ensureTrailingBackslash(parent._namespace + childNamespace);
-      }
+    if(childNamespace.size() > 0 && childNamespace[0] == '/')
+    {
+      _namespace = ensureTrailingBackslash(childNamespace);
+    }
+    else
+    {
+      _namespace = ensureTrailingBackslash(parent._namespace + childNamespace);
+    }
 
     if(_namespace.size() > 0 && _namespace[0] != '/')
-      _namespace = "/" + _namespace;    
+      _namespace = "/" + _namespace;
+  }
+
+  ConstPropertyTree::~ConstPropertyTree()
+  {
+  }
+
+
+  PropertyTree::PropertyTree(boost::shared_ptr<PropertyTreeImplementation> imp, const std::string & baseNamespace) :
+    ConstPropertyTree(imp, baseNamespace)
+  {
+  }
+
+
+  PropertyTree::PropertyTree(const PropertyTree & parent, const std::string & childNamespace) :
+    ConstPropertyTree(parent, childNamespace)
+  {
   }
 
 
@@ -33,7 +49,7 @@ namespace sm {
   }
 
   // \todo This function could do more name checking.
-  std::string PropertyTree::buildQualifiedKeyName(const std::string & key) const
+  std::string ConstPropertyTree::buildQualifiedKeyName(const std::string & key) const
   {
     std::string qualifiedKeyName = !key.empty() && key[0] == '/' ? key : _namespace + key;
     if(qualifiedKeyName.size() > 1 && qualifiedKeyName.back() == '/'){
@@ -42,16 +58,16 @@ namespace sm {
     return qualifiedKeyName;
   }
 
-  double PropertyTree::getDouble(const std::string & key) const
+  double ConstPropertyTree::getDouble(const std::string & key) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
     return _imp->getDouble(buildQualifiedKeyName(key));
   }
 
-  double PropertyTree::getDouble(const std::string & key, double defaultValue) const
+  double ConstPropertyTree::getDouble(const std::string & key, double defaultValue) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
-      return _imp->getDouble(buildQualifiedKeyName(key), defaultValue);
+      return boost::const_pointer_cast<const PropertyTreeImplementation>(_imp)->getDouble(buildQualifiedKeyName(key), defaultValue);
   }
 
   double PropertyTree::getDouble(const std::string & key, double defaultValue)
@@ -60,16 +76,16 @@ namespace sm {
     return _imp->getDouble(buildQualifiedKeyName(key), defaultValue);
   }
   
-  int PropertyTree::getInt(const std::string & key) const
+  int ConstPropertyTree::getInt(const std::string & key) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
     return _imp->getInt(buildQualifiedKeyName(key));
   }
 
-  int PropertyTree::getInt(const std::string & key, int defaultValue) const
+  int ConstPropertyTree::getInt(const std::string & key, int defaultValue) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
-    return _imp->getInt(buildQualifiedKeyName(key),defaultValue);
+    return boost::const_pointer_cast<const PropertyTreeImplementation>(_imp)->getInt(buildQualifiedKeyName(key),defaultValue);
   }
 
   int PropertyTree::getInt(const std::string & key, int defaultValue)
@@ -78,16 +94,16 @@ namespace sm {
     return _imp->getInt(buildQualifiedKeyName(key),defaultValue);
   }
 
-  bool PropertyTree::getBool(const std::string & key) const
+  bool ConstPropertyTree::getBool(const std::string & key) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
     return _imp->getBool(buildQualifiedKeyName(key));
   }
 
-  bool PropertyTree::getBool(const std::string & key, bool defaultValue) const
+  bool ConstPropertyTree::getBool(const std::string & key, bool defaultValue) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
-    return _imp->getBool(buildQualifiedKeyName(key), defaultValue);
+    return boost::const_pointer_cast<const PropertyTreeImplementation>(_imp)->getBool(buildQualifiedKeyName(key), defaultValue);
   }
 
   bool PropertyTree::getBool(const std::string & key, bool defaultValue) 
@@ -96,17 +112,16 @@ namespace sm {
     return _imp->getBool(buildQualifiedKeyName(key), defaultValue);
   }
 
-  
-  std::string PropertyTree::getString(const std::string & key) const
+  std::string ConstPropertyTree::getString(const std::string & key) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
     return _imp->getString(buildQualifiedKeyName(key));
   }
 
-  std::string PropertyTree::getString(const std::string & key, const std::string & defaultValue) const
+  std::string ConstPropertyTree::getString(const std::string & key, const std::string & defaultValue) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
-    return _imp->getString(buildQualifiedKeyName(key), defaultValue);
+    return boost::const_pointer_cast<const PropertyTreeImplementation>(_imp)->getString(buildQualifiedKeyName(key), defaultValue);
   }
 
   std::string PropertyTree::getString(const std::string & key, const std::string & defaultValue) 
@@ -115,7 +130,7 @@ namespace sm {
     return _imp->getString(buildQualifiedKeyName(key), defaultValue);
   }
   
-  bool PropertyTree::doesKeyExist(const std::string & key) const
+  bool ConstPropertyTree::doesKeyExist(const std::string & key) const
   {
       SM_ASSERT_TRUE(Exception, _imp, "The implementation is NULL");
     return _imp->doesKeyExist(buildQualifiedKeyName(key));
@@ -146,11 +161,17 @@ namespace sm {
     return _imp->setString(buildQualifiedKeyName(key), value);
   }
 
-  const std::vector<KeyPropertyTreePair> PropertyTree::getChildren() const {
-    return _imp->getChildren(_namespace);
+  std::vector<ConstKeyPropertyTreePair> ConstPropertyTree::getChildren() const {
+    std::vector<ConstKeyPropertyTreePair> cchildren;
+    auto children = _imp->getChildren(_namespace);
+    cchildren.reserve(children.size());
+    for (auto & kptp : children) {
+      cchildren.push_back(ConstKeyPropertyTreePair{kptp.key, kptp.pt});
+    }
+    return cchildren;
   }
 
-  std::vector<KeyPropertyTreePair> PropertyTree::getChildren() {
+  std::vector<KeyPropertyTreePair> PropertyTree::getChildren() const {
     return _imp->getChildren(_namespace);
   }
   

--- a/sm_property_tree/test/BoostPropertyTreeImplementation.cpp
+++ b/sm_property_tree/test/BoostPropertyTreeImplementation.cpp
@@ -39,7 +39,7 @@ TEST(PTreeTestSuite, testBoostPTree)
       ASSERT_NEAR(pt.getDouble("d/d"), 0.2, 1e-16);
       ASSERT_NEAR(pt.getDouble("/d/d"), 0.2, 1e-16);
       // Push a namespace on to the stack.
-      sm::PropertyTree dpt(pt,"d");
+      sm::ConstPropertyTree dpt(pt,"d");
       ASSERT_NEAR(dpt.getDouble("d"), 0.2, 1e-16);
       ASSERT_NEAR(dpt.getDouble("/d"), 0.1, 1e-16);
       ASSERT_NEAR(dpt.getDouble("/d/d"), 0.2, 1e-16);
@@ -49,7 +49,7 @@ TEST(PTreeTestSuite, testBoostPTree)
       ASSERT_EQ(pt.getInt("i/i"), 2);
       ASSERT_EQ(pt.getInt("/i/i"), 2);
       // Push a namespace on to the stack.
-      sm::PropertyTree ipt(pt,"i");
+      sm::ConstPropertyTree ipt(pt,"i");
       ASSERT_EQ(ipt.getInt(""), 1);
       ASSERT_EQ(ipt.getInt("i"), 2);
       ASSERT_EQ(ipt.getInt("/i"), 1);
@@ -60,7 +60,7 @@ TEST(PTreeTestSuite, testBoostPTree)
       ASSERT_EQ(pt.getBool("b/b"), false);
       ASSERT_EQ(pt.getBool("/b/b"), false);
       // Push a namespace on to the stack.
-      sm::PropertyTree bpt(pt,"b");
+      sm::ConstPropertyTree bpt(pt,"b");
       ASSERT_EQ(bpt.getBool(""), true);
       ASSERT_EQ(bpt.getBool("b"), false);
       ASSERT_EQ(bpt.getBool("/b"), true);
@@ -72,7 +72,7 @@ TEST(PTreeTestSuite, testBoostPTree)
       ASSERT_EQ(pt.getString("s/s"), std::string("goodbye"));
       ASSERT_EQ(pt.getString("/s/s"), std::string("goodbye"));
       // Push a namespace on to the stack.
-      sm::PropertyTree spt(pt,"s");
+      sm::ConstPropertyTree spt(pt,"s");
       ASSERT_EQ(spt.getString(""), std::string("hello"));
       ASSERT_EQ(spt.getString("s"), std::string("goodbye"));
       ASSERT_EQ(spt.getString("/s"), std::string("hello"));
@@ -103,7 +103,7 @@ TEST(PTreeTestSuite, testBoostPTree)
       {
         std::vector<const char *> expectedKeys{"s"};
         int i = 0;
-        for (auto & c2 : sm::PropertyTree(pt, "s").getChildren()){
+        for (auto & c2 : sm::ConstPropertyTree(pt, "s").getChildren()){
           ASSERT_LT(i, expectedKeys.size());
           EXPECT_EQ(expectedKeys[i++], c2.key);
         }

--- a/sm_python/src/exportPropertyTree.cpp
+++ b/sm_python/src/exportPropertyTree.cpp
@@ -1,35 +1,35 @@
 #include <numpy_eigen/boost_python_headers.hpp>
 #include <sm/BoostPropertyTree.hpp>
 
-double getDouble(const sm::PropertyTree * p, const std::string & key) {
+double getDouble(const sm::ConstPropertyTree * p, const std::string & key) {
   return p->getDouble(key);
 }
 
-double getDoubleDefault(sm::PropertyTree * p, const std::string & key, double defaultValue) {
+double getDoubleDefault(sm::ConstPropertyTree * p, const std::string & key, double defaultValue) {
   return p->getDouble(key, defaultValue);
 }
 
-int getInt(const sm::PropertyTree * p, const std::string & key) {
+int getInt(const sm::ConstPropertyTree * p, const std::string & key) {
   return p->getInt(key);
 }
 
-int getIntDefault(sm::PropertyTree * p, const std::string & key, int defaultValue) {
+int getIntDefault(sm::ConstPropertyTree * p, const std::string & key, int defaultValue) {
   return p->getInt(key, defaultValue);
 }
 
-bool getBool(const sm::PropertyTree * p, const std::string & key) {
+bool getBool(const sm::ConstPropertyTree * p, const std::string & key) {
   return p->getBool(key);
 }
 
-bool getBoolDefault(sm::PropertyTree * p, const std::string & key, bool defaultValue) {
+bool getBoolDefault(sm::ConstPropertyTree * p, const std::string & key, bool defaultValue) {
   return p->getBool(key, defaultValue);
 }
 
-std::string getString(const sm::PropertyTree * p, const std::string & key) {
+std::string getString(const sm::ConstPropertyTree * p, const std::string & key) {
   return p->getString(key);
 }
 
-std::string getStringDefault(sm::PropertyTree * p, const std::string & key, const std::string & defaultValue) {
+std::string getStringDefault(sm::ConstPropertyTree * p, const std::string & key, const std::string & defaultValue) {
   return p->getString(key, defaultValue);
 }
 
@@ -37,17 +37,24 @@ void exportPropertyTree() {
   using namespace boost::python;
   using namespace sm;
 
-  class_<PropertyTree>("PropertyTree", init<const PropertyTree &, const std::string &>("PropertyTree(PropertyTree parent, string childNamespace)"))
+  class_<ConstPropertyTree>("ConstPropertyTree", init<const ConstPropertyTree &, const std::string &>("ConstPropertyTree(ConstPropertyTree parent, string childNamespace)"))
       .def("getInt", &getInt).def("getIntDefault", &getIntDefault)
       .def("getString", &getString)
       .def("getStringDefault", &getStringDefault)
       .def("getBool", &getBool).def("getBoolDefault", &getBoolDefault)
       .def("getDouble", &getDouble).def("getDoubleDefault", &getDoubleDefault)
+      .def("doesKeyExist", &ConstPropertyTree::doesKeyExist);
+
+  class_<PropertyTree, bases<ConstPropertyTree>>("PropertyTree", init<const PropertyTree &, const std::string &>("PropertyTree(PropertyTree parent, string childNamespace)"))
+      .def("getOrCreateInt", static_cast<int(PropertyTree::*)(const std::string &, int)>(&PropertyTree::getInt))
+      .def("getOrCreateString", static_cast<std::string(PropertyTree::*)(const std::string &, const std::string&)>(&PropertyTree::getString))
+      .def("getOrCreatetBool", static_cast<bool(PropertyTree::*)(const std::string &, bool)>(&PropertyTree::getBool))
+      .def("getOrCreateDouble", static_cast<double(PropertyTree::*)(const std::string &, double)>(&PropertyTree::getDouble))
       .def("setInt", &PropertyTree::setInt)
       .def("setBool", &PropertyTree::setBool)
       .def("setString", &PropertyTree::setString)
       .def("setDouble", &PropertyTree::setDouble)
-      .def("doesKeyExist", &PropertyTree::doesKeyExist);
+      ;
 
   class_<BoostPropertyTree, bases<PropertyTree> >("BoostPropertyTree", init<>())
       .def(init<std::string>("BoostPropertyTree( string baseNamespace )"))

--- a/sm_python/test/Test.py
+++ b/sm_python/test/Test.py
@@ -33,7 +33,11 @@ class TestNsecTime(unittest.TestCase):
   def test_secToNsec(self):
     self.assertEqual(sm.secToNsec(1), 1.0e9)
 
+class TestPropertyTree(unittest.TestCase):
+  def test_boostpropertyTree(self):
+    bpt = sm.BoostPropertyTree()
+    bpt.setDouble("bla", 0.3)
+    self.assertEqual(bpt.getDouble("bla"), 0.3)
+
 if __name__ == '__main__':
-    import rostest
-    rostest.rosrun('sm_python', 'TestMatrixArchive', TestMatrixArchive)
-    rostest.rosrun('sm_python', 'TestNsecTime', TestNsecTime)
+    unittest.main()


### PR DESCRIPTION
With this PR the normal `sm::PropertyTree` stays **read/write**. A new **read only** class , `sm::ConstPropertyTree` which is `sm::PropertyTree`'s new base class.
