### PR TITLE
Fix timestamp corrector intermediate overflow

### DIFF
--- a/sm_timing/CMakeLists.txt
+++ b/sm_timing/CMakeLists.txt
@@ -20,6 +20,9 @@ cs_add_library(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 
+FILE(GLOB_RECURSE LibFiles "include/*")
+add_custom_target(headers SOURCES ${LibFiles})
+
 #############
 ## Testing ##
 #############

--- a/sm_timing/CMakeLists.txt
+++ b/sm_timing/CMakeLists.txt
@@ -20,9 +20,6 @@ cs_add_library(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 
-FILE(GLOB_RECURSE LibFiles "include/*")
-add_custom_target(headers SOURCES ${LibFiles})
-
 #############
 ## Testing ##
 #############

--- a/sm_timing/include/sm/timing/TimestampCorrector.hpp
+++ b/sm_timing/include/sm/timing/TimestampCorrector.hpp
@@ -77,19 +77,18 @@ namespace sm {
       }
     private:
       
-      class Point
-      {
-      public:
-	Point(const time_t & x, const time_t & y) : x(x), y(y) {}
-	// remote time
-	time_t x;
-	// local time
-	time_t y;
+      class Point {
+        public:
+          Point(const time_t & x, const time_t & y) : x(x), y(y) {}
+          // remote time
+          time_t x;
+          // local time
+          time_t y;
 
-	Point operator-(const Point & p) const { return Point(x - p.x, y - p.y); }
-	Point operator+(const Point & p) const { return Point(x + p.x, y + p.y); }
-	bool operator<(const Point & p) const { return x < p.x; }
-	bool operator<(const time_t & t) const { return x < t; }
+        Point operator-(const Point& p) const { return Point(x - p.x, y - p.y); }
+        Point operator+(const Point& p) const { return Point(x + p.x, y + p.y); }
+        bool operator<(const Point& p) const { return x < p.x; }
+        bool operator<(const time_t& t) const { return x < t; }
       };
 
       /** 
@@ -100,7 +99,7 @@ namespace sm {
        * 
        * @return true if the point is above the line.
        */
-      bool isAboveTopLine( const Point & p ) const;
+      bool isAboveTopLine(const Point& p) const;
 
       /** 
        * Is the point, p, above the line defined by the points l1 and l2?
@@ -111,7 +110,7 @@ namespace sm {
        * 
        * @return 
        */
-      bool isAboveLine( const Point & l1, const Point & l2, const Point & p ) const;
+      bool isAboveLine(const Point& l1, const Point& l2, const Point& p) const;
 
       typedef std::vector< Point > convex_hull_t;
       convex_hull_t _convexHull;

--- a/sm_timing/include/sm/timing/TimestampCorrector.hpp
+++ b/sm_timing/include/sm/timing/TimestampCorrector.hpp
@@ -67,7 +67,7 @@ namespace sm {
       
       void printHullPoints()
       {
-	for(unsigned i = 0; i < _convexHull.size(); ++i)
+	for(unsigned i = 0u; i < _convexHull.size(); ++i)
 	  {
 	    std::cout << i << "\t" << _convexHull[i].x << "\t" << _convexHull[i].y;
 	    if(i == _midpointSegmentIndex)

--- a/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
+++ b/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
@@ -2,7 +2,7 @@ namespace sm {
 namespace timing {
     
 template<typename T>
-TimestampCorrector<T>::TimestampCorrector() : _midpointSegmentIndex(0) {}
+TimestampCorrector<T>::TimestampCorrector() : _midpointSegmentIndex(0u) {}
 
 template<typename T>
 TimestampCorrector<T>::~TimestampCorrector() {}
@@ -23,7 +23,7 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(
   // If the point is not above the top line in the stack      
   if(!isAboveTopLine(p)) {
     // While on the top of the stack points are above a line between two back and the new point... 
-    while(_convexHull.size() >= 2 &&
+    while(_convexHull.size() >= 2u &&
         isAboveLine(_convexHull[_convexHull.size() - 2u], p, _convexHull[_convexHull.size() - 1u]) ) {
       _convexHull.pop_back();
     }
@@ -34,20 +34,20 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(
 
   // Update the midpoint pointer...
   if(_convexHull.size() >= 3u) {
-    T midpoint = (_convexHull[0u].x + remoteTime) / 2.0;
+    T midpoint = static_cast<T>((_convexHull[0u].x + remoteTime) / 2.0);
 	  
     typename convex_hull_t::iterator lbit = std::lower_bound(_convexHull.begin(),
                                                              _convexHull.end(), midpoint);
-    _midpointSegmentIndex = lbit - _convexHull.begin() - 1;
-    SM_ASSERT_LT_DBG(Exception, _midpointSegmentIndex, _convexHull.size() - 1,
+    _midpointSegmentIndex = lbit - _convexHull.begin() - 1u;
+    SM_ASSERT_LT_DBG(Exception, _midpointSegmentIndex, _convexHull.size() - 1u,
                      "The computed midpoint segment is out of bounds. Elements in hull: "
-                     << _convexHull.size() << ", Start time: " << _convexHull[0].x
-                     << ", End time: " << _convexHull[_convexHull.size() - 1].x
+                     << _convexHull.size() << ", Start time: " << _convexHull[0u].x
+                     << ", End time: " << _convexHull[_convexHull.size() - 1u].x
                      << ", midpoint: " << midpoint);
 
     SM_ASSERT_GE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex].x,
                      "The computed midpoint is not within the midpoint segment");
-    SM_ASSERT_LE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex + 1].x,
+    SM_ASSERT_LE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex + 1u].x,
                      "The computed midpoint is not within the midpoint segment");
   }
   else {
@@ -67,7 +67,7 @@ double TimestampCorrector<T>::getSlope() const {
 
   // Get the line at the time midpoint.
   const Point& l1 = _convexHull[_midpointSegmentIndex];
-  const Point& l2 = _convexHull[_midpointSegmentIndex + 1];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
 
   // Look up the local timestamp.
   return  double(l2.y - l1.y) / double(l2.x - l1.x);
@@ -80,7 +80,7 @@ double TimestampCorrector<T>::getOffset() const {
                "before this function can be called");
   // Get the line at the time midpoint.
   const Point& l1 = _convexHull[_midpointSegmentIndex];
-  const Point& l2 = _convexHull[_midpointSegmentIndex + 1];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
   
   // Look up the local timestamp.
   return  double(l1.y) + (double(-l1.x) * double(l2.y - l1.y) / double(l2.x - l1.x) );
@@ -91,7 +91,7 @@ double TimestampCorrector<T>::getOffset() const {
 template<typename T>
 typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
     const time_t& remoteTime) const {
-  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2,
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
                "The timestamp correction requires at least two data "
                "points before this funciton can be called");
 
@@ -100,7 +100,7 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
   const Point& l2 = _convexHull[_midpointSegmentIndex + 1];
 
   // Look up the local timestamp.
-  SM_ASSERT_GT(NotInitializedException, l2.x - l1.x, 0, "Division by zero not allowed.");
+  SM_ASSERT_GT(NotInitializedException, l2.x - l1.x, 0u, "Division by zero not allowed.");
   const double helper = static_cast<double>(l2.y - l1.y) / static_cast<double>(l2.x - l1.x);
   const typename TimestampCorrector<T>::time_t local_time =
       static_cast<typename TimestampCorrector<T>::time_t>(
@@ -109,7 +109,7 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
 
 template<typename T>
 bool TimestampCorrector<T>::isAboveTopLine(const Point& p) const {
-  if(_convexHull.size() < 2) {
+  if(_convexHull.size() < 2u) {
     return true;
   }
             

--- a/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
+++ b/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
@@ -97,15 +97,14 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
 
   // Get the line at the time midpoint.
   const Point& l1 = _convexHull[_midpointSegmentIndex];
-  const Point& l2 = _convexHull[_midpointSegmentIndex + 1];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1u];
 
   // Look up the local timestamp.
-  SM_ASSERT_GT(NotInitializedException, l2.x - l1.x, 0u, "Division by zero not allowed.");
   const double helper = static_cast<double>(l2.y - l1.y) / static_cast<double>(l2.x - l1.x);
-  const typename TimestampCorrector<T>::time_t local_time =
-      static_cast<typename TimestampCorrector<T>::time_t>(
+  const time_t local_time = static_cast<time_t>(
           static_cast<double>(l1.y) + helper * static_cast<double>(remoteTime - l1.x));
-  return local_time;}
+  return local_time;
+}
 
 template<typename T>
 bool TimestampCorrector<T>::isAboveTopLine(const Point& p) const {

--- a/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
+++ b/sm_timing/include/sm/timing/implementation/TimestampCorrector.hpp
@@ -1,39 +1,30 @@
-
-
 namespace sm {
 namespace timing {
     
 template<typename T>
-TimestampCorrector<T>::TimestampCorrector() : _midpointSegmentIndex(0)
-{
-      
-}
+TimestampCorrector<T>::TimestampCorrector() : _midpointSegmentIndex(0) {}
 
 template<typename T>
-TimestampCorrector<T>::~TimestampCorrector()
-{
-
-}
-
+TimestampCorrector<T>::~TimestampCorrector() {}
 
 // Returns the local time
 template<typename T>
-typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(const time_t & remoteTime, const time_t & localTime)
-{
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(
+    const time_t& remoteTime, const time_t& localTime) {
   // Make sure this point is forward in time.
-  if(!_convexHull.empty())
-  {
-    SM_ASSERT_GT(TimeWentBackwardsException, remoteTime, _convexHull[_convexHull.size() - 1].x, "The correction algorithm requires that times are passed in with monotonically increasing remote timestamps");
+  if(!_convexHull.empty()) {
+    SM_ASSERT_GT(TimeWentBackwardsException, remoteTime, _convexHull[_convexHull.size() - 1u].x,
+                 "The correction algorithm requires that times are passed in with monotonically "
+                 "increasing remote timestamps");
   }
 
   Point p(remoteTime, localTime);
 
   // If the point is not above the top line in the stack      
-  if( !isAboveTopLine( p ) )
-  {
+  if(!isAboveTopLine(p)) {
     // While on the top of the stack points are above a line between two back and the new point... 
-    while(_convexHull.size() >= 2 && isAboveLine(_convexHull[_convexHull.size() - 2], p, _convexHull[_convexHull.size() - 1]) )
-    {
+    while(_convexHull.size() >= 2 &&
+        isAboveLine(_convexHull[_convexHull.size() - 2u], p, _convexHull[_convexHull.size() - 1u]) ) {
       _convexHull.pop_back();
     }
   }
@@ -42,21 +33,24 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(c
   _convexHull.push_back(p);
 
   // Update the midpoint pointer...
-  if(_convexHull.size() >= 3)
-  {
-    T midpoint = (_convexHull[0].x + remoteTime) / 2.0;
+  if(_convexHull.size() >= 3u) {
+    T midpoint = (_convexHull[0u].x + remoteTime) / 2.0;
 	  
-    typename convex_hull_t::iterator lbit = std::lower_bound(_convexHull.begin(), _convexHull.end(), midpoint);
+    typename convex_hull_t::iterator lbit = std::lower_bound(_convexHull.begin(),
+                                                             _convexHull.end(), midpoint);
     _midpointSegmentIndex = lbit - _convexHull.begin() - 1;
-    SM_ASSERT_LT_DBG(Exception, _midpointSegmentIndex, _convexHull.size() - 1, "The computed midpoint segment is out of bounds. Elements in hull: " 
-                     << _convexHull.size() << ", Start time: " << _convexHull[0].x << ", End time: " << _convexHull[_convexHull.size() - 1].x 
+    SM_ASSERT_LT_DBG(Exception, _midpointSegmentIndex, _convexHull.size() - 1,
+                     "The computed midpoint segment is out of bounds. Elements in hull: "
+                     << _convexHull.size() << ", Start time: " << _convexHull[0].x
+                     << ", End time: " << _convexHull[_convexHull.size() - 1].x
                      << ", midpoint: " << midpoint);
 
-    SM_ASSERT_GE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex].x, "The computed midpoint is not within the midpoint segment");
-    SM_ASSERT_LE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex + 1].x, "The computed midpoint is not within the midpoint segment");
+    SM_ASSERT_GE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex].x,
+                     "The computed midpoint is not within the midpoint segment");
+    SM_ASSERT_LE_DBG(Exception, midpoint, _convexHull[_midpointSegmentIndex + 1].x,
+                     "The computed midpoint is not within the midpoint segment");
   }
-  else
-  {
+  else {
     // and if there aren't enough data points, just return the sampled local time.
     return localTime;
   }
@@ -67,11 +61,13 @@ typename TimestampCorrector<T>::time_t TimestampCorrector<T>::correctTimestamp(c
 
 template<typename T>
 double TimestampCorrector<T>::getSlope() const {
-  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2, "The timestamp correction requires at least two data points before this funciton can be called");
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
+               "The timestamp correction requires at least two data points "
+               "before this funciton can be called");
 
   // Get the line at the time midpoint.
-  const Point & l1 = _convexHull[_midpointSegmentIndex];
-  const Point & l2 = _convexHull[_midpointSegmentIndex + 1];
+  const Point& l1 = _convexHull[_midpointSegmentIndex];
+  const Point& l2 = _convexHull[_midpointSegmentIndex + 1];
 
   // look up the local timestamp
   return  double(l2.y - l1.y) / double(l2.x - l1.x); 
@@ -79,7 +75,9 @@ double TimestampCorrector<T>::getSlope() const {
 
 template<typename T>
 double TimestampCorrector<T>::getOffset() const {
-  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2, "The timestamp correction requires at least two data points before this funciton can be called");
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2u,
+               "The timestamp correction requires at least two data points "
+               "before this function can be called");
   // Get the line at the time midpoint.
   const Point & l1 = _convexHull[_midpointSegmentIndex];
   const Point & l2 = _convexHull[_midpointSegmentIndex + 1];
@@ -91,46 +89,51 @@ double TimestampCorrector<T>::getOffset() const {
   
 // Get the local time from the remote time.
 template<typename T>
-typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(const time_t & remoteTime) const
-{
-  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2, "The timestamp correction requires at least two data points before this funciton can be called");
+typename TimestampCorrector<T>::time_t TimestampCorrector<T>::getLocalTime(
+    const time_t& remoteTime) const {
+  SM_ASSERT_GE(NotInitializedException, _convexHull.size(), 2,
+               "The timestamp correction requires at least two data"
+               " points before this funciton can be called");
 
   // Get the line at the time midpoint.
   const Point & l1 = _convexHull[_midpointSegmentIndex];
   const Point & l2 = _convexHull[_midpointSegmentIndex + 1];
 
   // look up the local timestamp
-  return  l1.y + ((remoteTime - l1.x) * (l2.y - l1.y) / (l2.x - l1.x) ); 
+  const double factor_x =
+      static_cast<double>(remoteTime - l1.x) / static_cast<double>(l2.x - l1.x);
+  //std::cout << "Factor_x = " << factor_x << std::endl;
+  const typename TimestampCorrector<T>::time_t local_time =
+      static_cast<typename TimestampCorrector<T>::time_t>(
+          static_cast<double>(l1.y + (factor_x * static_cast<double>(l2.y - l1.y))));
+  //std::cout << "Calculated " << local_time << " = " << l1.y
+  //    << " + ((" <<  remoteTime << " - " << l1.x << ") * ("
+  //    << l2.y << " - " << l1.y << ") / (" << l2.x
+  //    << " - " << l1.x << "))" << std::endl;
+  return local_time;
 }
 
 template<typename T>
-bool TimestampCorrector<T>::isAboveTopLine(const Point & p) const
-{
-  if(_convexHull.size() < 2)
-  {
+bool TimestampCorrector<T>::isAboveTopLine(const Point& p) const {
+  if(_convexHull.size() < 2) {
     return true;
   }
             
-  return isAboveLine(_convexHull[ _convexHull.size() - 2 ],
-                     _convexHull[ _convexHull.size() - 1],
+  return isAboveLine(_convexHull[ _convexHull.size() - 2u],
+                     _convexHull[ _convexHull.size() - 1u],
                      p);
-      
-      
 }
 
 template<typename T>
-bool TimestampCorrector<T>::isAboveLine(const Point & l1, const Point & l2, const Point & p) const
-{
+bool TimestampCorrector<T>::isAboveLine(const Point & l1, const Point & l2, const Point & p) const {
   Point v1 = l2 - l1;
   Point v2 = p - l1;
       
   T determinant = v1.x * v2.y - v1.y * v2.x;
+  //std::cout << "Calculated " << determinant << " = " << v1.x << "*" << v2.y << " - " << v1.y << "*" << v2.x << std::endl;
 
   return determinant >= 0.0;
 }
-
-
-
 
 } // namespace timing
 } // namespace sm


### PR DESCRIPTION
Relevant lines start [here](https://github.com/ethz-asl/Schweizer-Messer/compare/ethz-asl:d2d6a6a...ethz-asl:671db52#diff-9df708da0b9c55ac142ff1cbf8424a63R104). Rest is mostly formatting and avoiding int to uint casts.

We have observed an overflow for the returned local time (I don't remember which part was causing the overflow). The interpolation operation should be done with floating point operations anyway.